### PR TITLE
Add Minecraft 26.1.1 target while keeping 26.1 build support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## 2.2.2 - 2026-04-05
+
+### Changed
+- Added Minecraft `26.1.1` as active Stonecutter target.
+- Kept parallel build support for both `26.1` and `26.1.1` because no code-level compatibility changes were required between these patch versions.
+
 ## 2.2.1 - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ScamScreener is a client-side Fabric mod that analyzes incoming chat, highlights
 
 ## Supported Versions And Requirements
 
-- Minecraft: `26.1`
+- Minecraft: `26.1.1` (primär), `26.1` (parallel verfügbar)
 - Java: `25`
 - Mod loader: Fabric Loader `>= 0.18.5`
 - Dependency: Fabric API

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,8 +15,8 @@ plugins {
 
 stonecutter {
     create(rootProject) {
-        versions("26.1")
-        vcsVersion = "26.1"
+        versions("26.1", "26.1.1")
+        vcsVersion = "26.1.1"
     }
 }
 

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("me.modmuss50.mod-publish-plugin") version "1.0.+" apply false
 }
 
-stonecutter active "26.1"
+stonecutter active "26.1.1"
 
 stonecutter tasks {
     order("publishMods")

--- a/versions/26.1.1/gradle.properties
+++ b/versions/26.1.1/gradle.properties
@@ -1,0 +1,11 @@
+deps.fabric_api=0.144.3+26.1
+deps.modmenu_version=18.0.0-alpha.8
+
+# Minecraft dependency for fabric.mod.json
+mod.mc_dep=26.1.1
+
+# Release title for Modrinth and Curseforge
+mod.mc_title=26.1.1
+
+# Space-separated compatible versions for publishing
+mod.mc_targets=26.1.1


### PR DESCRIPTION
### Motivation
- Bump the active Stonecutter Minecraft target to `26.1.1` to publish a build for the new patch while preserving existing `26.1` artifacts when no code changes are required. 

### Description
- Switched active Stonecutter target from `26.1` to `26.1.1` in `stonecutter.gradle.kts`. 
- Added `26.1.1` to the Stonecutter version matrix and set `vcsVersion = "26.1.1"` in `settings.gradle.kts` so both `26.1` and `26.1.1` builds are available. 
- Added `versions/26.1.1/gradle.properties` profile with Minecraft metadata for `26.1.1` and left Fabric API coordinates unchanged where compatible. 
- Updated `README.md` supported-versions line and added a `2.2.2` entry to `CHANGELOG.md` documenting the new active target. 

### Testing
- Attempted to list Gradle tasks with `./gradlew tasks --all` to validate the build setup, but plugin resolution for `net.fabricmc.fabric-loom:1.15.5` failed in this environment and the command aborted before project evaluation. 
- No automated unit tests were run because the Gradle invocation could not complete due to the plugin resolution failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24d2457208325a82e80d8ca51def2)